### PR TITLE
fix false negative values cause NaN

### DIFF
--- a/dist/grid.js
+++ b/dist/grid.js
@@ -29,7 +29,6 @@ var InfiniteGrid = function (_React$Component) {
 
 	_createClass(InfiniteGrid, [{
 		key: 'initialState',
-		// function to wrap Item components (for use with MobX), defaults to returning the component itself
 		value: function initialState() {
 			return {
 				initiatedLazyload: false,
@@ -59,7 +58,8 @@ var InfiniteGrid = function (_React$Component) {
 				buffer: _react2.default.PropTypes.number,
 				gridStyle: _react2.default.PropTypes.object,
 				shouldComponentUpdate: _react2.default.PropTypes.func,
-				itemWrapper: _react2.default.PropTypes.func };
+				itemWrapper: _react2.default.PropTypes.func // function to wrap Item components (for use with MobX), defaults to returning the component itself
+			};
 		}
 	}]);
 
@@ -124,12 +124,12 @@ var InfiniteGrid = function (_React$Component) {
 
 			// The number of rows that the user has scrolled past
 			var scrolledPast = this._scrolledPastRows() * itemsPerRow;
-			if (scrolledPast < 0) scrolledPast = 0;
+			if (this._isNegative(scrolledPast)) scrolledPast = 0;
 
 			// If i have scrolled past 20 items, but 60 are visible on screen,
 			// we do not want to change the minimum
 			var min = scrolledPast - itemsPerRow;
-			if (min < 0) min = 0;
+			if (this._isNegative(min)) min = 0;
 
 			// the maximum should be the number of items scrolled past, plus some
 			// buffer
@@ -160,13 +160,15 @@ var InfiniteGrid = function (_React$Component) {
 	}, {
 		key: '_itemsPerRow',
 		value: function _itemsPerRow() {
-			return Math.floor(this._getGridRect().width / this._itemWidth());
+			var itemsPerRow = Math.floor(this._getGridRect().width / this._itemWidth());
+			if (itemsPerRow === 0) return 1;
+			return itemsPerRow;
 		}
 	}, {
 		key: '_totalRows',
 		value: function _totalRows() {
 			var scrolledPastHeight = this.props.entries.length / this._itemsPerRow() * this._itemHeight();
-			if (scrolledPastHeight < 0) return 0;
+			if (this._isNegative(scrolledPastHeight)) return 0;
 			return scrolledPastHeight;
 		}
 	}, {
@@ -198,6 +200,11 @@ var InfiniteGrid = function (_React$Component) {
 				this.setState({ initiatedLazyload: true });
 				this.props.lazyCallback(this.state.maxItemIndex);
 			}
+		}
+	}, {
+		key: '_isNegative',
+		value: function _isNegative(n) {
+			return ((n = +n) || 1 / n) < 0;
 		}
 
 		// LIFECYCLE

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.10.0",
+    "lodash": "^4.15.0",
     "react": "^15.0.2",
     "react-dom": "^15.0.2"
   },

--- a/src/grid.js
+++ b/src/grid.js
@@ -88,12 +88,12 @@ export default class InfiniteGrid extends React.Component {
 
 		// The number of rows that the user has scrolled past
 		var scrolledPast = (this._scrolledPastRows() * itemsPerRow);
-		if (scrolledPast < 0) scrolledPast = 0;
+		if (this._isNegative(scrolledPast)) scrolledPast = 0;
 
 		// If i have scrolled past 20 items, but 60 are visible on screen,
 		// we do not want to change the minimum
 		var min = scrolledPast - itemsPerRow;
-		if (min < 0) min = 0;
+		if (this._isNegative(min)) min = 0;
 
 		// the maximum should be the number of items scrolled past, plus some
 		// buffer
@@ -122,12 +122,14 @@ export default class InfiniteGrid extends React.Component {
 	}
 
 	_itemsPerRow() {
-		return Math.floor(this._getGridRect().width / this._itemWidth());
+		const itemsPerRow = Math.floor(this._getGridRect().width / this._itemWidth());
+		if (itemsPerRow === 0) return 1;
+		return itemsPerRow;
 	}
 
 	_totalRows() {
 		const scrolledPastHeight = (this.props.entries.length / this._itemsPerRow()) * this._itemHeight();
-		if (scrolledPastHeight < 0) return 0;
+		if (this._isNegative(scrolledPastHeight)) return 0;
 		return scrolledPastHeight;
 	}
 
@@ -154,6 +156,10 @@ export default class InfiniteGrid extends React.Component {
 			this.setState({initiatedLazyload: true });
 			this.props.lazyCallback(this.state.maxItemIndex);
 		}
+	}
+
+	_isNegative(n) {
+		return ((n = +n) || 1 / n) < 0;
 	}
 
 	// LIFECYCLE


### PR DESCRIPTION
sometimes error happens when `item.js#35` left css with NaN.

it caused by negative value of `scrolledPast`

`-0 < 0` is false, so I added `_isNegative()`

and the other hands, `itemsPerRow` must same or higher than 1.
